### PR TITLE
Fix 59 seconds

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time "0.9.0"]
+                 [clj-time "0.12.0"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
                    :plugins [[lein-cljfmt "0.1.10"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-cron-parse "0.1.5-SNAPSHOT"
+(defproject org.clojars.quartet/clj-cron-parse "0.1.6-SNAPSHOT"
   :description "A Clojure library for using cron expressions"
   :url "https://github.com/shmish111/clj-cron-parse"
   :license {:name "Eclipse Public License"

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -202,12 +202,10 @@
   [now sec]
   (match sec
     ([& xs] :seq)
-    (let [this-minute (t/to-time-zone (t/floor now t/minute) (.getZone now))
-          ns (next-date-time (t/plus now (t/seconds 1))
-                             (map #(t/plus this-minute (t/seconds %)) xs))]
-      (if ns
-        ns
-        (t/plus now (t/minutes 1) (t/seconds (- (first xs) (t/second now))))))
+    (let [this-minute (t/to-time-zone (t/floor now t/minute) (.getZone now))]
+      (or (next-date-time (t/plus now (t/seconds 1))
+                             (map #(t/plus this-minute (t/seconds %)) xs))
+          (t/plus now (t/minutes 1) (t/seconds (- (first xs) (t/second now))))))
     :else now))
 
 (defn now-with-minutes

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -204,7 +204,7 @@
     ([& xs] :seq)
     (let [this-minute (t/to-time-zone (t/floor now t/minute) (.getZone now))]
       (or (next-date-time (t/plus now (t/seconds 1))
-                             (map #(t/plus this-minute (t/seconds %)) xs))
+                          (map #(t/plus this-minute (t/seconds %)) xs))
           (t/plus now (t/minutes 1) (t/seconds (- (first xs) (t/second now))))))
     :else now))
 

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -9,10 +9,12 @@
              (= d actual))))
 
 (def now (t/date-time 2015 01 01 12 00 00 000))
+(def now2 (t/date-time 2015 01 01 12 00 59 000))
 (def nye (t/date-time 2014 12 31 12 00 00 000))
 
 (time (facts "should find next date for cron expression"
              (next-date now "1 * * * * *") => (date 2015 01 01 12 00 01 000)
+             (next-date now2 "0 * * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* 1 * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* * 13 * * *") => (date 2015 01 01 13 00 00 000)
              (next-date now "* * * 10 * *") => (date 2015 01 10 12 00 00 000)

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -9,12 +9,10 @@
              (= d actual))))
 
 (def now (t/date-time 2015 01 01 12 00 00 000))
-(def now2 (t/date-time 2015 01 01 12 00 59 000))
 (def nye (t/date-time 2014 12 31 12 00 00 000))
 
 (time (facts "should find next date for cron expression"
              (next-date now "1 * * * * *") => (date 2015 01 01 12 00 01 000)
-             (next-date now2 "0 * * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* 1 * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* * 13 * * *") => (date 2015 01 01 13 00 00 000)
              (next-date now "* * * 10 * *") => (date 2015 01 10 12 00 00 000)
@@ -78,7 +76,12 @@
              (next-date now "@midnight") => (date 2015 01 02 00 00 00 000)
              (next-date now "@hourly") => (date 2015 01 01 13 00 00 000)
              (next-date (t/date-time 2015 04 22 06 22 29 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)
-             (next-date (t/date-time 2015 04 21 06 22 30 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)))
+             (next-date (t/date-time 2015 04 21 06 22 30 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)
+             (next-date (t/date-time 2015 04 21 06 00 59 000) "0 * * * * *") => (date 2015 04 21 06 01 00 000)
+             (next-date (t/date-time 2015 04 21 06 59 00 000) "* 0 * * * *") => (date 2015 04 21 07 00 00 000)
+             (next-date (t/date-time 2015 04 21 23 00 00 000) "* * 0 * * *") => (date 2015 04 22 00 00 00 000)
+             (next-date (t/date-time 2015 04 30 00 00 00 000) "* * * 1 * *") => (date 2015 05 01 00 00 00 000)
+             (next-date (t/date-time 2015 04 21 23 59 59 000) "0 * * * * *") => (date 2015 04 22 00 00 00 000)))
 
 ;; TODO: close to new year, combinations, range/n for dow
 


### PR DESCRIPTION
Hi! I found a bug while using your library- 

``` clojure
(next-date (t/date-time 2015 04 21 06 00 59 000) "0 * * * * *")
```

incorrectly yields

```
#<DateTime 2015-04-21T06:00:00.000Z>
```

rather than the correct 

```
#<DateTime 2015-04-21T06:01:00.000Z>
```

This PR fixes that bug, and adds a test to demonstrate. I also added some tests around other overflow behavior.

`clj-time` gets a version bump in order to use the relatively new `t/equal?`

Thanks!
