### PR TITLE
fix: Full hour wrap around (and update all libs in the meantime)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,11 @@
   :url "https://github.com/finity-ai/clj-cron-parse"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time "0.9.0"]
-                 [org.clojure/core.match "0.3.0-alpha4"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [clj-time "0.15.2"]
+
+                 [org.clojure/core.match "1.0.0"]]
   :pedantic? :abort
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-cljfmt "0.1.10"]
-                             [lein-midje "3.1.3"]]}})
+  :profiles {:dev {:dependencies [[midje "1.10.5"]]
+                   :plugins [[lein-cljfmt "0.8.0"]
+                             [lein-midje "3.2.2"]]}})

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -130,7 +130,9 @@
 
 (defn next-divisible
   [x d]
-  (* d (+ 1 (quot x d))))
+  (if (= x 0)
+    0
+    (* d (+ 1 (quot x d)))))
 
 (defn parse-field
   [minimum maximum range-fn s]
@@ -356,6 +358,7 @@
                    by-dow (next-date-by-dow now cron-map)]
                (-> [by-dom by-dow] sort first)))
      nil))
+
   ([now cron timezone]
    (if timezone
      (let [tz-now (t/to-time-zone now (t/time-zone-for-id timezone))]

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -13,6 +13,7 @@
 
 (time (facts "should find next date for cron expression"
              (next-date now "1 * * * * *") => (date 2015 01 01 12 00 01 000)
+             (next-date (t/date-time 2022 05 24 10 59 00) "0 */5 * * * *") => (t/date-time 2022 05 24 11 00 00)
              (next-date now "* 1 * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* * 13 * * *") => (date 2015 01 01 13 00 00 000)
              (next-date now "* * * 10 * *") => (date 2015 01 10 12 00 00 000)
@@ -27,7 +28,7 @@
              (next-date now "1-20/2 * * * * *") => (date 2015 01 01 12 00 01 000)
              (next-date (t/date-time 2015 01 01 12 00 04 000) "3-20/2 * * * * *") => (date 2015 01 01 12 00 05 000)
              (next-date now "* 1,2 * * * *") => (date 2015 01 01 12 01 00 000)
-             (next-date now "* */2 * * * *") => (date 2015 01 01 12 02 00 000)
+             (next-date now "* */2 * * * *") => (date 2015 01 01 12 00 00 000)
              (next-date now "* 1-20 * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date now "* 1-20/2 * * * *") => (date 2015 01 01 12 01 00 000)
              (next-date (t/date-time 2015 01 01 12 05 00 000) "* 1-20/3 * * * *") => (date 2015 01 01 12 07 00 000)


### PR DESCRIPTION
We're using your nice library in production and have found a bug. Our service is supposed to do something every 5 minutes, all day long. Our schedule is `"0 */5 * * * *"`. This schedule will run every five minutes, however, it will omit the full hour. This PR fixes this. Using the pathfinder principle, I have also updated all libraries in `project.clj`. The tests are all green for me.

A test is included. One other test had to be updated because it actually had the wrong expectation.

Thank you for your great work :pray: I hope you can merge this PR and push a new release to Clojars, soon. 